### PR TITLE
Return an empty response from the default virtual server

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,31 +1,10 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-
-    server_name _;
-
-    location / {
-        try_files $uri $uri/ =404;
-    }
-}
-
-server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
-
-    root /usr/share/nginx/html;
-    index index.html index.htm;
-
-    ssl on;
     ssl_certificate /etc/nginx/ssl/cert.pem;
     ssl_certificate_key /etc/nginx/ssl/key.pem;
-
-    server_name _;
-
-    location / {
-        try_files $uri $uri/ =404;
-    }
+    access_log off;
+    return 444;
 }


### PR DESCRIPTION
The default server should not disclose any details about itself and that's basically what this PR introduces.

```
$ curl -vvv http://127.0.0.1/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1
> User-Agent: curl/7.54.1
> Accept: */*
>
* Empty reply from server
* Connection #0 to host 31.24.64.60 left intact
curl: (52) Empty reply from server
```