### PR TITLE
Add no-cache headers to 404 and other error status codes

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -57,11 +57,11 @@ http {
     ##
     # Cache
     ##
-    add_header Cache-Control private;
-    add_header Cache-Control no-cache;
-    add_header Cache-Control no-store;
-    add_header Cache-Control must-revalidate;
-    add_header Pragma no-cache;
+    add_header Cache-Control private always;
+    add_header Cache-Control no-cache always;
+    add_header Cache-Control no-store always;
+    add_header Cache-Control must-revalidate always;
+    add_header Pragma no-cache always;
 
     ##
     # SSL


### PR DESCRIPTION
http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header

> [add_header] Adds the specified field to a response header provided
> that the response code equals 200, 201, 204, 206, 301, 302, 303, 304,
> 307, or 308. The value can contain variables.
>
> If the always parameter is specified, the header field will be added
> regardless of the response code.

This commit adds the `always` parameter to all the default `add_header`
directives, so that we turn off cache for 404 and other status codes as
well. This avoids browsers caching accidental 404s. For example, a page
could make a request to a JS file that is not available because of
deployment issues. When the issues are resolved one would want the
browser to try the request again without having to clear cache.