### PR TITLE
Remove rate limit

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -126,12 +126,6 @@ http {
         https on;
     }
 
-    ###
-    # Throttling
-    ##
-    # We limit on IP (single machine)
-    limit_req_zone  $binary_remote_addr  zone=one:10m   rate=5r/s;
-
     ##
     # Virtual Host Configs
     ##


### PR DESCRIPTION
5 requests per second is very low, especially since the rate limit doesn't take upstream proxies such as Cloudflare into consideration (many clients share the same IP).